### PR TITLE
update mobject for new SSG API changes

### DIFF
--- a/src/client/aio/aio-cluster-operate.c
+++ b/src/client/aio/aio-cluster-operate.c
@@ -21,9 +21,10 @@ int mobject_store_aio_write_op_operate(mobject_store_write_op_t   write_op,
                                        int                        flags)
 {
     // XXX pick other servers using ch-placement
-    ssg_member_id_t svr_id
-        = ssg_get_group_member_id_from_rank(io->cluster->gid, 0);
-    hg_addr_t svr_addr = ssg_get_group_member_addr(io->cluster->gid, svr_id);
+    ssg_member_id_t svr_id;
+    ssg_get_group_member_id_from_rank(io->cluster->gid, 0, &svr_id);
+    hg_addr_t svr_addr;
+    ssg_get_group_member_addr(io->cluster->gid, svr_id, &svr_addr);
 
     mobject_provider_handle_t mph;
     mobject_provider_handle_create(io->cluster->mobject_clt, svr_addr, 1, &mph);
@@ -44,9 +45,10 @@ int mobject_store_aio_read_op_operate(mobject_store_read_op_t    read_op,
                                       int                        flags)
 {
     // XXX pick other servers using ch-placement
-    ssg_member_id_t svr_id
-        = ssg_get_group_member_id_from_rank(io->cluster->gid, 0);
-    hg_addr_t svr_addr = ssg_get_group_member_addr(io->cluster->gid, svr_id);
+    ssg_member_id_t svr_id;
+    ssg_get_group_member_id_from_rank(io->cluster->gid, 0, &svr_id);
+    hg_addr_t svr_addr;
+    ssg_get_group_member_addr(io->cluster->gid, svr_id, &svr_addr);
 
     mobject_provider_handle_t mph;
     mobject_provider_handle_create(io->cluster->mobject_clt, svr_addr, 1, &mph);

--- a/src/server/mobject-server-ctl.c
+++ b/src/server/mobject-server-ctl.c
@@ -86,8 +86,8 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    server_addr_str = ssg_group_id_get_addr_str(server_gid, 0);
-    if (!server_addr_str) {
+    ret = ssg_group_id_get_addr_str(server_gid, 0, &server_addr_str);
+    if (ret != SSG_SUCCESS) {
         fprintf(stderr,
                 "Error: Unable to get mobject server group address string\n");
         ssg_finalize();
@@ -124,8 +124,8 @@ int main(int argc, char* argv[])
         return (-1);
     }
 
-    group_size = ssg_get_group_size(server_gid);
-    if (group_size == 0) {
+    ret = ssg_get_group_size(server_gid, &group_size);
+    if (ret != SSG_SUCCESS) {
         fprintf(stderr, "Error: Unable to determine SSG server group size\n");
         ssg_group_unobserve(server_gid);
         margo_finalize(mid);
@@ -135,8 +135,8 @@ int main(int argc, char* argv[])
     }
 
     for (i = 0; i < group_size; i++) {
-        server_id   = ssg_get_group_member_id_from_rank(server_gid, i);
-        server_addr = ssg_get_group_member_addr(server_gid, server_id);
+        ssg_get_group_member_id_from_rank(server_gid, i, &server_id);
+        ssg_get_group_member_addr(server_gid, server_id, &server_addr);
         if (server_addr == HG_ADDR_NULL) {
             fprintf(stderr, "Error: NULL address given for group member %d\n",
                     i);


### PR DESCRIPTION
SSG's API recently changed to have all function calls return error codes -- this required some pretty simple changes to shift around what were once return values into pass by reference values.