### PR TITLE
ci: fix failiures

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -1,4 +1,4 @@
-name: spack mobject
+name: spack mobject mpich
 
 on:
   push:
@@ -14,17 +14,53 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Spack
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: spack/spack
         path: ./spack
     - name: Checkout mochi-spack-packages
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: mochi-hpc/mochi-spack-packages
         path: ./mochi-spack-packages
-    - name: Run a multi-line script
+    - name: Install APT Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -q -y autoconf
+        sudo apt-get install -q -y automake
+        sudo apt-get install -q -y cmake
+        sudo apt-get install -q -y libtool
+        sudo apt-get install -q -y libtool-bin
+        sudo apt-get install -q -y mpich
+        sudo apt-get install -q -y zlib1g-dev
+        sudo apt-get install -q -y diffutils
+        sudo apt-get install -q -y libdb-dev         
+        sudo apt-get install -q -y libedit-dev
+        sudo apt-get install -q -y libncurses6
+        sudo apt-get install -q -y libxml2-dev
+        sudo apt-get install -q -y openssl        
+    - name: Run spack install mobject
       run: |
         . ./spack/share/spack/setup-env.sh
+        spack compiler find
+        spack compilers
+        spack external find autoconf
+        spack external find automake
+        spack external find berkeley-db
+        spack external find boost
+        spack external find cmake
+        spack external find diffutils
+        spack external find libedit
+        spack external find libtool
+        spack external find libiconv
+        spack external find libxml2
+        spack external find m4
+        spack external find mpich
+        spack external find ncurses
+        spack external find openssl
+        spack external find perl
+        spack external find pkgconf
+        spack external find zlib
+        spack external find xz        
         spack repo add ./mochi-spack-packages
-        spack install --test root mobject
+        spack install mobject

--- a/.github/workflows/spack_bedrock.yml
+++ b/.github/workflows/spack_bedrock.yml
@@ -13,13 +13,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Install APT Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gfortran-12    
     - name: Checkout Spack
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: spack/spack
         path: ./spack
     - name: Checkout mochi-spack-packages
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: mochi-hpc/mochi-spack-packages
         path: ./mochi-spack-packages
@@ -27,4 +31,4 @@ jobs:
       run: |
         . ./spack/share/spack/setup-env.sh
         spack repo add ./mochi-spack-packages
-        spack install --test root mobject+bedrock
+        spack install mobject+bedrock


### PR DESCRIPTION
GitHub ubuntu-latest now uses 22.04.
This will fix build failures.
This PR tests mpich as well.