### PR TITLE
Multiple bake targets and provider handle per mobject provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ built using a composition of [Mochi](https://mochi.readthedocs.io) components:
  * [mochi-bake](https://github.com/mochi-hpc/mochi-bake) (for bulk storage)
  * [mochi-bedrock](https://github.com/mochi-hpc/mochi-bedrock) 
    (for configuration and bootstrapping) 
- * [mochi-sdskv](https://github.com/mochi-hpc/mochi-sdskv)
+ * [mochi-yokan](https://github.com/mochi-hpc/mochi-yokan)
    (for metadata and log indexing)
  * [mochi-ssg](https://github.com/mochi-hpc/mochi-ssg) (for group membership)
 

--- a/include/mobject-server.h
+++ b/include/mobject-server.h
@@ -29,7 +29,8 @@ struct mobject_provider_init_args {
  *
  * @param[in] mid           margo instance id
  * @param[in] provider_id   id of the provider
- * @param[in] bake_ph       Bake provider handle to use to write/read data
+ * @param[in] num_bake_phs  Number of bake provider handles
+ * @param[in] bake_phs      Bake provider handles to use to write/read data
  * @param[in] yokan_ph      Yokan provider handle to use to access metadata
  *                          providers
  * @param[in] args          Optional arguments
@@ -39,7 +40,8 @@ struct mobject_provider_init_args {
  */
 int mobject_provider_register(margo_instance_id                  mid,
                               uint16_t                           provider_id,
-                              bake_provider_handle_t             bake_ph,
+                              unsigned                           num_bake_phs,
+                              const bake_provider_handle_t*      bake_phs,
                               yk_provider_handle_t               yokan_ph,
                               struct mobject_provider_init_args* args,
                               mobject_provider_t*                provider);

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,3 +13,7 @@ spack:
   concretizer:
     unify: true
     reuse: false
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]

--- a/src/server/core/core-read-op.cpp
+++ b/src/server/core/core-read-op.cpp
@@ -108,14 +108,11 @@ void read_op_exec_read(void*    u,
     auto              vargs = static_cast<server_visitor_args_t>(u);
     margo_instance_id mid   = vargs->provider->mid;
     ENTERING;
-    bake_provider_handle_t bph = vargs->provider->bake_ph;
-    bake_target_id_t       bti = vargs->provider->bake_tid;
-    bake_region_id_t       rid;
-    hg_bulk_t              remote_bulk     = vargs->bulk_handle;
-    const char*            remote_addr_str = vargs->client_addr_str;
-    hg_addr_t              remote_addr     = vargs->client_addr;
-    yk_database_handle_t   seg_dbh         = vargs->provider->segment_dbh;
-    yk_return_t            yret;
+    hg_bulk_t            remote_bulk     = vargs->bulk_handle;
+    const char*          remote_addr_str = vargs->client_addr_str;
+    hg_addr_t            remote_addr     = vargs->client_addr;
+    yk_database_handle_t seg_dbh         = vargs->provider->segment_dbh;
+    yk_return_t          yret;
 
     uint64_t client_start_index = offset;
     uint64_t client_end_index   = offset + len;
@@ -141,8 +138,8 @@ void read_op_exec_read(void*    u,
     size_t        max_segments = 128; // XXX this is a pretty arbitrary number
     segment_key_t segment_keys[max_segments];
     hg_size_t     segment_keys_size[max_segments];
-    bake_region_id_t segment_data[max_segments];
-    hg_size_t        segment_data_size[max_segments];
+    region_descriptor_t segment_data[max_segments];
+    hg_size_t           segment_data_size[max_segments];
 
     bool done          = false;
     int  seg_start_ndx = 0;
@@ -151,15 +148,15 @@ void read_op_exec_read(void*    u,
 
         yret = yk_list_keyvals_packed(
             seg_dbh, YOKAN_MODE_DEFAULT, (const void*)&lb,
-            sizeof(lb),                              /* strict lower bound */
-            (const void*)&oid, sizeof(oid),          /* prefix */
-            max_segments,                            /* count */
-            segment_keys,                            /* keys buffer */
-            max_segments * sizeof(segment_key_t),    /* keys buffer size */
-            segment_keys_size,                       /* key sizes */
-            segment_data,                            /* data buffer */
-            max_segments * sizeof(bake_region_id_t), /* data buffer size */
-            segment_data_size);                      /* data sizes */
+            sizeof(lb),                                 /* strict lower bound */
+            (const void*)&oid, sizeof(oid),             /* prefix */
+            max_segments,                               /* count */
+            segment_keys,                               /* keys buffer */
+            max_segments * sizeof(segment_key_t),       /* keys buffer size */
+            segment_keys_size,                          /* key sizes */
+            segment_data,                               /* data buffer */
+            max_segments * sizeof(region_descriptor_t), /* data buffer size */
+            segment_data_size);                         /* data sizes */
 
         if (yret != YOKAN_SUCCESS) {
             margo_error(mid,
@@ -173,8 +170,8 @@ void read_op_exec_read(void*    u,
         size_t i;
         for (i = seg_start_ndx; i < max_segments; i++) {
 
-            const segment_key_t&    seg    = segment_keys[i];
-            const bake_region_id_t& region = segment_data[i];
+            const segment_key_t&       seg    = segment_keys[i];
+            const region_descriptor_t& region = segment_data[i];
 
             if (segment_keys_size[i] == YOKAN_NO_MORE_KEYS || seg.oid != oid
                 || coverage.full()) {
@@ -193,16 +190,35 @@ void read_op_exec_read(void*    u,
                 break;
 
             case seg_type_t::BAKE_REGION: {
+                // find the bake provider handle associated with the target
+                bake_provider_handle_t bake_ph = BAKE_PROVIDER_HANDLE_NULL;
+                for (unsigned i = 0; i < vargs->provider->num_bake_targets;
+                     i++) {
+                    if (memcmp(&region.tid,
+                               &vargs->provider->bake_targets[i].tid,
+                               sizeof(bake_target_id_t))
+                        == 0) {
+                        bake_ph = vargs->provider->bake_targets[i].ph;
+                    }
+                }
+                if (!bake_ph) {
+                    margo_error(mid,
+                                "[mobject] %s:%d: could not find bake provider "
+                                "handle associated with stored target id",
+                                __func__, __LINE__);
+                    LEAVING;
+                    return;
+                }
                 auto ranges = coverage.set(seg.start_index, seg.end_index);
                 for (auto r : ranges) {
                     uint64_t segment_size  = r.end - r.start;
                     uint64_t region_offset = r.start - seg.start_index;
                     uint64_t remote_offset = r.start - offset;
                     uint64_t bytes_read    = 0;
-                    int bret = bake_proxy_read(bph, bti, region, region_offset,
-                                               remote_bulk, remote_offset,
-                                               remote_addr_str, segment_size,
-                                               &bytes_read);
+                    int bret = bake_proxy_read(bake_ph, region.tid, region.rid,
+                                               region_offset, remote_bulk,
+                                               remote_offset, remote_addr_str,
+                                               segment_size, &bytes_read);
                     if (bret != 0) {
                         *prval = -1;
                         margo_error(

--- a/src/server/core/core-read-op.cpp
+++ b/src/server/core/core-read-op.cpp
@@ -192,13 +192,14 @@ void read_op_exec_read(void*    u,
             case seg_type_t::BAKE_REGION: {
                 // find the bake provider handle associated with the target
                 bake_provider_handle_t bake_ph = BAKE_PROVIDER_HANDLE_NULL;
-                for (unsigned i = 0; i < vargs->provider->num_bake_targets;
-                     i++) {
+                for (unsigned j = 0; j < vargs->provider->num_bake_targets;
+                     j++) {
                     if (memcmp(&region.tid,
-                               &vargs->provider->bake_targets[i].tid,
+                               &vargs->provider->bake_targets[j].tid,
                                sizeof(bake_target_id_t))
                         == 0) {
-                        bake_ph = vargs->provider->bake_targets[i].ph;
+                        bake_ph = vargs->provider->bake_targets[j].ph;
+                        break;
                     }
                 }
                 if (!bake_ph) {

--- a/src/server/core/key-types.h
+++ b/src/server/core/key-types.h
@@ -44,6 +44,11 @@ typedef struct segment_key_t {
     uint64_t end_index;   // end index is not included
 } segment_key_t;
 
+typedef struct region_descriptor_t {
+    bake_target_id_t tid;
+    bake_region_id_t rid;
+} region_descriptor_t;
+
 typedef struct omap_key_t {
     oid_t oid;
     char  key[1];
@@ -52,6 +57,6 @@ typedef struct omap_key_t {
 #define MAX_OMAP_KEY_SIZE 128
 #define MAX_OMAP_VAL_SIZE 256
 
-#define SMALL_REGION_THRESHOLD (sizeof(bake_region_id_t))
+#define SMALL_REGION_THRESHOLD (sizeof(region_descriptor_t))
 
 #endif

--- a/src/server/mobject-provider.h
+++ b/src/server/mobject-provider.h
@@ -18,16 +18,21 @@ extern "C" {
 
 #define MOBJECT_SEQ_ID_MAX UINT32_MAX
 
+struct mobject_bake_target {
+    bake_provider_handle_t ph;
+    bake_target_id_t       tid;
+};
+
 struct mobject_provider {
     /* margo/ABT state */
     margo_instance_id mid;
     uint16_t          provider_id;
     ABT_pool          pool;
-    ABT_mutex         mutex;
-    ABT_mutex         stats_mutex;
+    ABT_mutex_memory  mutex;
+    ABT_mutex_memory  stats_mutex;
     /* bake-related data */
-    bake_provider_handle_t bake_ph;
-    bake_target_id_t       bake_tid;
+    unsigned                    num_bake_targets;
+    struct mobject_bake_target* bake_targets;
     /* yokan-related data */
     yk_database_handle_t oid_dbh;
     yk_database_handle_t name_dbh;

--- a/tests/config.json
+++ b/tests/config.json
@@ -82,7 +82,7 @@
             "provider_id" : 1,
             "config" : {},
             "dependencies" : {
-                "bake_provider_handle" : "storage@local",
+                "bake_provider_handles" : ["storage@local"],
                 "yokan_provider_handle" : "metadata@local"
             }
         }


### PR DESCRIPTION
This PR adds the possibility to have a mobject provider use multiple bake provider handle, each with potentially multiple targets.